### PR TITLE
Wanted Level Check fixes in "Treacherous Swine"

### DIFF
--- a/_source/MainSCM/source/generl1.txt
+++ b/_source/MainSCM/source/generl1.txt
@@ -1356,9 +1356,8 @@ jump @GENERL1_8885
 jump @GENERL1_8738
 
 :GENERL1_8713
-if and
+if
    not Player.WantedLevel($PLAYER_CHAR) > 0
-   80E0:   not player $PLAYER_CHAR driving
 jf @GENERL1_8738
 jump @GENERL1_8885
 
@@ -1366,16 +1365,14 @@ jump @GENERL1_8885
 if
   $2264 == 0 // integer values
 jf @GENERL1_8826
-if and
+if 
 00F5:   player $PLAYER_CHAR 1 327.2 429.9 10.3 radius 2.5 2.5 2.5
-00E0:   player $PLAYER_CHAR driving
+
 jf @GENERL1_8826
 03E5: text_box 'GEN1_22'  // Drive your vehicle into the spray shop to lose your ~h~wanted level, ~h~repair and ~h~respray your vehicle. Cost - ~h~$100. This time it's free.
 $2264 = 1 // integer values
 
 :GENERL1_8826
-if
-80E0:   not player $PLAYER_CHAR driving
 jf @GENERL1_8854
 Marker.Disable($2263)
 jump @GENERL1_8046


### PR DESCRIPTION
The Mission will now pass either way once the wanted level is lost, previously the mission wouldnt pass until the player was on foot, now it doesnt matter.