### PR TITLE
Slightly simplify R3 skip code by making the subroutine a conditional

### DIFF
--- a/_source/MainSCM/main.txt
+++ b/_source/MainSCM/main.txt
@@ -6509,7 +6509,8 @@ else
         end
     end
 end
-return
+$MISSION_CANCEL_FLAG == 2 // Comparison is intended here, do not "fix" it
+return                    // This will make this subroutine "return" the result of that comparison
 
 :IS_SCENE_SKIPPED
 if 15@ == 0

--- a/_source/MainSCM/source/ambulan.txt
+++ b/_source/MainSCM/source/ambulan.txt
@@ -396,8 +396,7 @@ jf @AMBULAN_2555
 0293: $18 = get_controller_mode
 if $6761 == 0
 then
-	gosub @PROCESS_R3_ABORT
-	if $MISSION_CANCEL_FLAG == 2
+	if gosub @PROCESS_R3_ABORT
 	then
 		$6761 = 1
 	end
@@ -899,8 +898,7 @@ wait 0
 0293: $18 = get_controller_mode
 if $6761 == 0
 then
-	gosub @PROCESS_R3_ABORT
-	if $MISSION_CANCEL_FLAG == 2
+	if gosub @PROCESS_R3_ABORT
 	then
 		$6761 = 1
 	end

--- a/_source/MainSCM/source/copcar.txt
+++ b/_source/MainSCM/source/copcar.txt
@@ -2068,8 +2068,7 @@ else
     end
 end
 0293: $18 = get_controller_mode
-gosub @PROCESS_R3_ABORT
-if $MISSION_CANCEL_FLAG == 2
+if gosub @PROCESS_R3_ABORT
 then
     00BC: text_highpriority 'C_CANC' 3000 ms 1  // ~r~Vigilante mission cancelled!
     $6902 = 1 // integer values
@@ -3033,8 +3032,7 @@ else
     end
 end
 0293: $18 = get_controller_mode
-gosub @PROCESS_R3_ABORT
-if $MISSION_CANCEL_FLAG == 2
+if gosub @PROCESS_R3_ABORT
 then
     00BC: text_highpriority 'C_CANC' 3000 ms 1  // ~r~Vigilante mission cancelled!
     $6902 = 1 // integer values
@@ -3052,8 +3050,7 @@ jf @COPCAR_16936
 053F: set_car $6875 tires_vulnerable 0
 if $6906 == 0
 then
-	gosub @PROCESS_R3_ABORT
-	if $MISSION_CANCEL_FLAG == 2
+	if gosub @PROCESS_R3_ABORT
 	then
 		$6906 = 1
 	end

--- a/_source/MainSCM/source/firetru.txt
+++ b/_source/MainSCM/source/firetru.txt
@@ -1025,8 +1025,7 @@ return
 0293: $18 = get_controller_mode
 if $6849 == 0
 then
-	gosub @PROCESS_R3_ABORT
-	if $MISSION_CANCEL_FLAG == 2
+	if gosub @PROCESS_R3_ABORT
 	then
 		$6849 = 1
 	end

--- a/_source/MainSCM/source/pizza.txt
+++ b/_source/MainSCM/source/pizza.txt
@@ -2671,8 +2671,7 @@ return
 :PIZZA_13772
 if $8017 == 0
 then
-	gosub @PROCESS_R3_ABORT
-	if $MISSION_CANCEL_FLAG == 2
+	if gosub @PROCESS_R3_ABORT
 	then
 		00BE: text_clear_all
 		$8015 = 3

--- a/_source/MainSCM/source/taxi.txt
+++ b/_source/MainSCM/source/taxi.txt
@@ -73,8 +73,7 @@ jf @TAXI_338
 jump @TAXI_6552
 
 :TAXI_338
-gosub @PROCESS_R3_ABORT
-if $MISSION_CANCEL_FLAG == 2
+if gosub @PROCESS_R3_ABORT
 then
     jump @TAXI_6347
 end
@@ -142,8 +141,7 @@ jf @TAXI_718
 jump @TAXI_6486
 
 :TAXI_718
-gosub @PROCESS_R3_ABORT
-if $MISSION_CANCEL_FLAG == 2
+if gosub @PROCESS_R3_ABORT
 then
     jump @TAXI_6347
 end
@@ -260,8 +258,7 @@ jf @TAXI_1470
 jump @TAXI_6486
 
 :TAXI_1470
-gosub @PROCESS_R3_ABORT
-if $MISSION_CANCEL_FLAG == 2
+if gosub @PROCESS_R3_ABORT
 then
     jump @TAXI_6347
 end
@@ -969,8 +966,7 @@ jump @TAXI_6552
 
 :TAXI_5693
 0293: $18 = get_controller_mode
-gosub @PROCESS_R3_ABORT
-if $MISSION_CANCEL_FLAG == 2
+if gosub @PROCESS_R3_ABORT
 then
     jump @TAXI_6347
 end
@@ -1172,8 +1168,7 @@ jump @TAXI_6876
 
 :TAXI_6734
 0293: $18 = get_controller_mode
-gosub @PROCESS_R3_ABORT
-if $MISSION_CANCEL_FLAG == 2
+if gosub @PROCESS_R3_ABORT
 then
     jump @TAXI_6876
 end


### PR DESCRIPTION
This abuses the fact comparison flags "stick" and thus gosubs can be treated as if they return condition results.